### PR TITLE
Fix warning

### DIFF
--- a/main.py
+++ b/main.py
@@ -491,9 +491,9 @@ class Picture:
 
         for size in self.thumbs:
             if not hq:
-                cr.thumbnail((size, size), Image.NEAREST)  # BILINEAR
+                cr.thumbnail((size, size), Image.Resampling.NEAREST)  # BILINEAR
             else:
-                cr.thumbnail((size, size), Image.ANTIALIAS)
+                cr.thumbnail((size, size), Image.Resampling.LANCZOS)
 
             w, h = cr.size
 


### PR DESCRIPTION
Fixes these following warnings:
```
/opt/avvie/main.py:496: DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
  cr.thumbnail((size, size), Image.ANTIALIAS)
/opt/avvie/main.py:494: DeprecationWarning: NEAREST is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.NEAREST or Dither.NONE instead.
  cr.thumbnail((size, size), Image.NEAREST)  # BILINEAR
```