### PR TITLE
application: Fix split sentence

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1902,7 +1902,7 @@ class Avvie:
         vbox2.append(m1)
 
 
-        m1 = Gtk.Button(label=_("About ") + app_title)
+        m1 = Gtk.Button(label=_("About %s") % app_title)
         m1.connect("clicked", self.show_about)
         vbox2.append(m1)
 


### PR DESCRIPTION
Split sentences are hard to translate.
Also, not all languages use SVO (Subject, Verb, Object) structure.

More information: https://wiki.gnome.org/TranslationProject/DevGuidelines/Never%20split%20sentences