### PR TITLE
Appdata and translation related patches

### DIFF
--- a/com.github.taiko2k.avvie.json
+++ b/com.github.taiko2k.avvie.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.github.taiko2k.avvie",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
+  "runtime-version": "45",
   "sdk": "org.gnome.Sdk",
   "command": "avvie",
   "finish-args": [

--- a/data/com.github.taiko2k.avvie.appdata.xml.in
+++ b/data/com.github.taiko2k.avvie.appdata.xml.in
@@ -10,6 +10,8 @@
   <project_license>GPL-3.0+</project_license>
   <url type="homepage">https://github.com/Taiko2k/avvie</url>
   <url type="bugtracker">https://github.com/Taiko2k/avvie/issues</url>
+  <url type="vcs-browser">https://github.com/Taiko2k/avvie</url>
+  <url type="translate">https://github.com/Taiko2k/Avvie/tree/master/po</url>
   <icon type="remote" height="256" width="256">https://user-images.githubusercontent.com/17271572/65506667-343ef700-df20-11e9-8590-14bfa569c3c2.png</icon>
 
   <description>
@@ -23,13 +25,9 @@
     </screenshot>
   </screenshots>
 
-  <categories>
-    <category>Graphics</category>
-  </categories>
-
   <releases>
     <release version="2.4" date="2023-07-14">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added option for lossless JPEG cropping</li>
           <li>Added option to set JPEG export quality</li>

--- a/po/avvie.pot
+++ b/po/avvie.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: avvie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-01 17:56+0200\n"
+"POT-Creation-Date: 2024-01-10 01:06+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,219 +17,264 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: data/com.github.taiko2k.avvie.desktop.in:3
+#: data/com.github.taiko2k.avvie.appdata.xml.in:5
+msgid "Avvie"
+msgstr ""
+
 #: data/com.github.taiko2k.avvie.desktop.in:4
 msgid "Image Cropper"
 msgstr ""
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:7
-msgid "Crop images for avatars or wallpapers"
+#: data/com.github.taiko2k.avvie.appdata.xml.in:6
+msgid "Taiko2k"
 msgstr ""
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:16
+#: data/com.github.taiko2k.avvie.appdata.xml.in:7
+msgid "Quick and easy image cropping"
+msgstr ""
+
+#: data/com.github.taiko2k.avvie.appdata.xml.in:18
 msgid ""
 "A simple tool for cropping and downsizing images. Suitable for avatars or "
 "cropping photos for use as desktop wallpapers. Convert PNG to JPG. Export in "
 "one click to your Pictures folder."
 msgstr ""
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:22
+#: data/com.github.taiko2k.avvie.appdata.xml.in:24
 msgid "Main window showing image with a crop selection"
 msgstr ""
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:34
-msgid "Added circle export mode"
-msgstr ""
-
-#: data/com.github.taiko2k.avvie.appdata.xml.in:35
-msgid "Tweaked preferences dialog layout"
-msgstr ""
-
-#: src/main.py:793
+#: src/main.py:888
 msgid "Behavior"
 msgstr ""
 
-#: src/main.py:800
-msgid "Export circle mode (PNG will use alpha mask)"
+#: src/main.py:893
+msgid "None"
 msgstr ""
 
-#: src/main.py:807
-msgid "Set quick export function"
+#: src/main.py:894
+msgid "Cross"
 msgstr ""
 
-#: src/main.py:812
-msgid "Export to Downloads"
+#: src/main.py:895
+msgid "Rule of thirds"
 msgstr ""
 
-#: src/main.py:820
-msgid "Export to Pictures"
+#: src/main.py:899
+msgid "Guide Mode"
 msgstr ""
 
-#: src/main.py:828
-msgid "Overwrite Source File"
-msgstr ""
-
-#: src/main.py:835
-msgid "Appearance"
-msgstr ""
-
-#: src/main.py:839
-msgid "Default"
-msgstr ""
-
-#: src/main.py:840
-msgid "Dark"
-msgstr ""
-
-#: src/main.py:841
-msgid "Pinku"
-msgstr ""
-
-#: src/main.py:844
-msgid "Theme"
-msgstr ""
-
-#: src/main.py:857 src/main.py:876
-msgid "Add Preview"
-msgstr ""
-
-#: src/main.py:871
-msgid "Add"
-msgstr ""
-
-#: src/main.py:925
-msgid "Show in Files"
-msgstr ""
-
-#: src/main.py:927
-msgid "Error!"
-msgstr ""
-
-#: src/main.py:928
-msgid "Could not locate output folder!"
-msgstr ""
-
-#: src/main.py:999
-msgid "Choose where to save"
-msgstr ""
-
-#: src/main.py:1003
-msgid "Image files"
-msgstr ""
-
-#: src/main.py:1010
-msgid "Choose an image file"
-msgstr ""
-
-#: src/main.py:1058
-msgid "Open image file"
-msgstr ""
-
-#: src/main.py:1076
-msgid "Options Menu"
-msgstr ""
-
-#: src/main.py:1083
-msgid "Enable Crop"
-msgstr ""
-
-#: src/main.py:1104
-msgid "Toggle Circle"
-msgstr ""
-
-#: src/main.py:1109
-msgid "Remove Preview"
-msgstr ""
-
-#: src/main.py:1131
-msgid "Export to Downloads folder"
-msgstr ""
-
-#: src/main.py:1132
-msgid "Image file exported to Downloads."
-msgstr ""
-
-#: src/main.py:1134
-msgid "Export to Pictures folder"
-msgstr ""
-
-#: src/main.py:1135
-msgid "Image file exported to Pictures."
-msgstr ""
-
-#: src/main.py:1137
-msgid "Overwrite Image"
-msgstr ""
-
-#: src/main.py:1138
-msgid "Image file overwritten."
-msgstr ""
-
-#: src/main.py:1762
+#: src/main.py:908 src/main.py:2077
 msgid "Square"
 msgstr ""
 
-#: src/main.py:1768
+#: src/main.py:909 src/main.py:2084
 msgid "Free Rectangle"
 msgstr ""
 
-#: src/main.py:1793 src/main.py:1853
+#: src/main.py:913 src/main.py:2117 src/main.py:2179
 msgid "Custom"
 msgstr ""
 
-#: src/main.py:1809
+#: src/main.py:917
+msgid "Default Aspect Ratio"
+msgstr ""
+
+#: src/main.py:940
+msgid "Export circle with circle preview mode"
+msgstr ""
+
+#: src/main.py:941
+msgid ""
+"You can click the thumbnail to toggle circle preview mode which doesn't "
+"affect output unless this setting is also enabled. PNG's will export with "
+"alpha mask. JPGs will export with white frame."
+msgstr ""
+
+#: src/main.py:953
+msgid "Lossless JPG cropping"
+msgstr ""
+
+#: src/main.py:954
+msgid ""
+"Lossless cropping is restricted to JPEG iMCU boundaries so selection may be "
+"trimmed. Not available with downscaling."
+msgstr ""
+
+#: src/main.py:967
+msgid "Export JPEG quality"
+msgstr ""
+
+#: src/main.py:974
+msgid "Set quick export function"
+msgstr ""
+
+#: src/main.py:979
+msgid "Export to Downloads"
+msgstr ""
+
+#: src/main.py:987
+msgid "Export to Pictures"
+msgstr ""
+
+#: src/main.py:995
+msgid "Overwrite Source File"
+msgstr ""
+
+#: src/main.py:1002
+msgid "Appearance"
+msgstr ""
+
+#: src/main.py:1006
+msgid "Default"
+msgstr ""
+
+#: src/main.py:1007
+msgid "Dark"
+msgstr ""
+
+#: src/main.py:1008
+msgid "Light"
+msgstr ""
+
+#: src/main.py:1009
+msgid "Sakura"
+msgstr ""
+
+#: src/main.py:1012
+msgid "Theme"
+msgstr ""
+
+#: src/main.py:1027 src/main.py:1046
+msgid "Add Preview"
+msgstr ""
+
+#: src/main.py:1041
+msgid "Add"
+msgstr ""
+
+#: src/main.py:1127
+msgid "Show in Files"
+msgstr ""
+
+#: src/main.py:1129
+msgid "Error!"
+msgstr ""
+
+#: src/main.py:1130
+msgid "Could not locate output folder!"
+msgstr ""
+
+#: src/main.py:1212
+msgid "Choose where to save"
+msgstr ""
+
+#: src/main.py:1215
+msgid "Image files"
+msgstr ""
+
+#: src/main.py:1226
+msgid "Choose an image file"
+msgstr ""
+
+#: src/main.py:1275
+msgid "Open image file"
+msgstr ""
+
+#: src/main.py:1305
+msgid "Options Menu"
+msgstr ""
+
+#: src/main.py:1312
+msgid "Enable Crop"
+msgstr ""
+
+#: src/main.py:1333
+msgid "Toggle Circle"
+msgstr ""
+
+#: src/main.py:1338
+msgid "Remove Preview"
+msgstr ""
+
+#: src/main.py:1447
+msgid "Export to Downloads folder"
+msgstr ""
+
+#: src/main.py:1448
+msgid "Image file exported to Downloads."
+msgstr ""
+
+#: src/main.py:1450
+msgid "Export to Pictures folder"
+msgstr ""
+
+#: src/main.py:1451
+msgid "Image file exported to Pictures."
+msgstr ""
+
+#: src/main.py:1453
+msgid "Overwrite Image"
+msgstr ""
+
+#: src/main.py:1454
+msgid "Image file overwritten."
+msgstr ""
+
+#: src/main.py:2135
 msgid "Reset rotation"
 msgstr ""
 
-#: src/main.py:1821
+#: src/main.py:2147
 msgid "Flip Vertical"
 msgstr ""
 
-#: src/main.py:1824
+#: src/main.py:2150
 msgid "Flip Horizontal"
 msgstr ""
 
-#: src/main.py:1837
+#: src/main.py:2163
 msgid "No Downscale"
 msgstr ""
 
-#: src/main.py:1842
+#: src/main.py:2168
 msgid "Max 184x184"
 msgstr ""
 
-#: src/main.py:1847
+#: src/main.py:2173
 msgid "Max 1000x1000"
 msgstr ""
 
-#: src/main.py:1872
+#: src/main.py:2198
 msgid "Export as PNG"
 msgstr ""
 
-#: src/main.py:1877
+#: src/main.py:2203
 msgid "Discard EXIF"
 msgstr ""
 
-#: src/main.py:1884
+#: src/main.py:2210
 msgid "Sharpen"
 msgstr ""
 
-#: src/main.py:1889
+#: src/main.py:2215
 msgid "Grayscale"
 msgstr ""
 
-#: src/main.py:1895
+#: src/main.py:2221
 msgid "Export As"
 msgstr ""
 
-#: src/main.py:1899
+#: src/main.py:2225
 msgid "Preferences"
 msgstr ""
 
-#. TRANSLATORS: After this we will add "Avvie", e.g. for english it will be "About Avvie"
-#: src/main.py:1904
-msgid "About "
+#: src/main.py:2230
+#, python-format
+msgid "About %s"
 msgstr ""
 
-#. TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-#: src/main.py:1990
+#: src/main.py:2312
 msgid "translator-credits"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,241 +1,290 @@
 # Turkish translation of com.github.taiko2k.avvie
-#
-# Copyright (C) 2022 com.github.taiko2k.avvie's COPYRIGHT HOLDER
+# Copyright (C) 2022-2024 com.github.taiko2k.avvie's COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.taiko2k.avvie package.
 #
-# Sabri Ünal <libreajans@gmail.com>, 2022.
+# Sabri Ünal <libreajans@gmail.com>, 2022, 2024.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: avvie\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-01 17:56+0200\n"
-"PO-Revision-Date: 2022-08-28 23:47+0300\n"
+"POT-Creation-Date: 2024-01-10 01:06+0300\n"
+"PO-Revision-Date: 2024-01-10 01:08+0300\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
-"Language-Team: Turkish <gnometurk@gnome.org>\n"
+"Language-Team: Turkish <takim@gnome.org.tr>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.1.1\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: data/com.github.taiko2k.avvie.desktop.in:3
+#: data/com.github.taiko2k.avvie.appdata.xml.in:5
+msgid "Avvie"
+msgstr "Avvie"
 
 #: data/com.github.taiko2k.avvie.desktop.in:4
 msgid "Image Cropper"
 msgstr "Resim Kırpıcı"
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:7
-msgid "Crop images for avatars or wallpapers"
-msgstr "Resimleri avatar veya duvar kağıtları için kırp"
+#: data/com.github.taiko2k.avvie.appdata.xml.in:6
+msgid "Taiko2k"
+msgstr "Taiko2k"
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:16
+#: data/com.github.taiko2k.avvie.appdata.xml.in:7
+msgid "Quick and easy image cropping"
+msgstr "Hızlı ve kolay resim kırpma"
+
+#: data/com.github.taiko2k.avvie.appdata.xml.in:18
 msgid ""
-"A simple tool cropping and downsizing images. Suitable for avatars or "
+"A simple tool for cropping and downsizing images. Suitable for avatars or "
 "cropping photos for use as desktop wallpapers. Convert PNG to JPG. Export in "
 "one click to your Pictures folder."
 msgstr ""
-"Resim kırpma ve küçültmek için bir araç. Resimleri avatar veya masaüstü "
-"duvar kağıdı olarak kullanmak için uygundur. PNG'yi JPG'e dönüştürün. Tek "
-"tıklamayla Resimler klasörünüze aktarın."
+"Resimleri kırpmak ve küçültmek için basit bir araç. Masaüstü duvar kağıdı  "
+"veya avatar olarak kullanmak üzere resimleri kırpmak için uygundur. PNG'yi "
+"JPG'ye dönüştürün. Tek tıklamayla Resimler klasörünüze aktarın."
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:22
+#: data/com.github.taiko2k.avvie.appdata.xml.in:24
 msgid "Main window showing image with a crop selection"
 msgstr "Kırpma seçimiyle resmi gösteren ana pencere"
 
-#: data/com.github.taiko2k.avvie.appdata.xml.in:34
-msgid "Added circle export mode"
-msgstr "Daire dışa aktarma kipi eklendi"
-
-#: data/com.github.taiko2k.avvie.appdata.xml.in:35
-msgid "Tweaked preferences dialog layout"
-msgstr "Tercihler yerleşim düzeni iyileştirildi"
-
-#: src/main.py:793
+#: src/main.py:888
 msgid "Behavior"
 msgstr "Davranış"
 
-#: src/main.py:800
-msgid "Export circle mode (PNG will use alpha mask)"
-msgstr "Daire kipinde dışa aktar (PNG, alfa maskesi kullanır)"
+#: src/main.py:893
+msgid "None"
+msgstr "Hiçbiri"
 
-#: src/main.py:807
-msgid "Set quick export function"
-msgstr "Hızlı dışa aktarma işlevini ayarla"
+#: src/main.py:894
+msgid "Cross"
+msgstr "Çarpı"
 
-#: src/main.py:812
-msgid "Export to Downloads"
-msgstr "İndirilenlere Dışa Aktar"
+#: src/main.py:895
+msgid "Rule of thirds"
+msgstr "Üçlü kuralı"
 
-#: src/main.py:820
-msgid "Export to Pictures"
-msgstr "Resimlere Dışa Aktar"
+#: src/main.py:899
+msgid "Guide Mode"
+msgstr "Kılavuz Kipi"
 
-#: src/main.py:828
-msgid "Overwrite Source File"
-msgstr "Kaynak Dosyanın Üzerine Yaz"
-
-#: src/main.py:835
-msgid "Appearance"
-msgstr "Görünüm"
-
-#: src/main.py:839
-msgid "Default"
-msgstr "Öntanımlı"
-
-#: src/main.py:840
-msgid "Dark"
-msgstr "Koyu"
-
-#: src/main.py:841
-msgid "Pinku"
-msgstr "Pembe"
-
-#: src/main.py:844
-msgid "Theme"
-msgstr "Tema"
-
-#: src/main.py:857 src/main.py:876
-msgid "Add Preview"
-msgstr "Önizleme Ekle"
-
-#: src/main.py:871
-msgid "Add"
-msgstr "Ekle"
-
-#: src/main.py:925
-msgid "Show in Files"
-msgstr "Dosyalarda Göster"
-
-#: src/main.py:927
-msgid "Error!"
-msgstr "Hata!"
-
-#: src/main.py:928
-msgid "Could not locate output folder!"
-msgstr "Çıktı klasörü bulunamadı!"
-
-#: src/main.py:999
-msgid "Choose where to save"
-msgstr "Nereye kaydedileceğini seç"
-
-#: src/main.py:1003
-msgid "Image files"
-msgstr "Resim dosyaları"
-
-#: src/main.py:1010
-msgid "Choose an image file"
-msgstr "Resim dosyası seç"
-
-#: src/main.py:1058
-msgid "Open image file"
-msgstr "Resim dosyası aç"
-
-#: src/main.py:1076
-msgid "Options Menu"
-msgstr "Seçenekler Menüsü"
-
-#: src/main.py:1083
-msgid "Enable Crop"
-msgstr "Kırpmayı Etkinleştir"
-
-#: src/main.py:1104
-msgid "Toggle Circle"
-msgstr "Daireyi Aç/Kapat"
-
-#: src/main.py:1109
-msgid "Remove Preview"
-msgstr "Önizlemeyi Kaldır"
-
-#: src/main.py:1131
-msgid "Export to Downloads folder"
-msgstr "İndirilenler klasörüne dışa aktar"
-
-#: src/main.py:1132
-msgid "Image file exported to Downloads."
-msgstr "Resim dosyası İndirilenler'e aktarıldı."
-
-#: src/main.py:1134
-msgid "Export to Pictures folder"
-msgstr "Resimler klasörüne aktar"
-
-#: src/main.py:1135
-msgid "Image file exported to Pictures."
-msgstr "Resim dosyası Resimler'e aktarıldı."
-
-#: src/main.py:1137
-msgid "Overwrite Image"
-msgstr "Resmin Üzerine Yaz"
-
-#: src/main.py:1138
-msgid "Image file overwritten."
-msgstr "Resim dosyasının üzerine yazıldı."
-
-#: src/main.py:1762
+#: src/main.py:908 src/main.py:2077
 msgid "Square"
 msgstr "Kare"
 
-#: src/main.py:1768
+#: src/main.py:909 src/main.py:2084
 msgid "Free Rectangle"
 msgstr "Serbest Dikdörtgen"
 
-#: src/main.py:1793 src/main.py:1853
+#: src/main.py:913 src/main.py:2117 src/main.py:2179
 msgid "Custom"
 msgstr "Özel"
 
-#: src/main.py:1809
+#: src/main.py:917
+msgid "Default Aspect Ratio"
+msgstr "Öntanımlı En Boy Oranı"
+
+#: src/main.py:940
+msgid "Export circle with circle preview mode"
+msgstr "Daire önizleme kipi ile daireyi dışa aktar"
+
+#: src/main.py:941
+msgid ""
+"You can click the thumbnail to toggle circle preview mode which doesn't "
+"affect output unless this setting is also enabled. PNG's will export with "
+"alpha mask. JPGs will export with white frame."
+msgstr ""
+"Bu ayar ayrıca etkinleştirilmediği sürece çıktıyı etkilemeyen daire önizleme "
+"kipini değiştirmek için küçük resme tıklayabilirsiniz. PNG resimler alfa "
+"maskesiyle dışa aktarılır. JPG resimler beyaz çerçeveyle dışa aktarılır."
+
+#: src/main.py:953
+msgid "Lossless JPG cropping"
+msgstr "Kayıpsız JPG kırpma"
+
+#: src/main.py:954
+msgid ""
+"Lossless cropping is restricted to JPEG iMCU boundaries so selection may be "
+"trimmed. Not available with downscaling."
+msgstr ""
+"Kayıpsız kırpma JPEG iMCU sınırlarıyla sınırlıdır, bu nedenle seçim "
+"kırpılabilir. Küçültme ile kullanılamaz."
+
+#: src/main.py:967
+msgid "Export JPEG quality"
+msgstr "Dışa aktarma JPEG kalitesi"
+
+#: src/main.py:974
+msgid "Set quick export function"
+msgstr "Hızlı dışa aktarma işlevini ayarla"
+
+#: src/main.py:979
+msgid "Export to Downloads"
+msgstr "İndirilenlere Dışa Aktar"
+
+#: src/main.py:987
+msgid "Export to Pictures"
+msgstr "Resimlere Dışa Aktar"
+
+#: src/main.py:995
+msgid "Overwrite Source File"
+msgstr "Kaynak Dosyanın Üzerine Yaz"
+
+#: src/main.py:1002
+msgid "Appearance"
+msgstr "Görünüm"
+
+#: src/main.py:1006
+msgid "Default"
+msgstr "Öntanımlı"
+
+#: src/main.py:1007
+msgid "Dark"
+msgstr "Koyu"
+
+#: src/main.py:1008
+msgid "Light"
+msgstr "Açık"
+
+#: src/main.py:1009
+msgid "Sakura"
+msgstr "Sakura"
+
+#: src/main.py:1012
+msgid "Theme"
+msgstr "Tema"
+
+#: src/main.py:1027 src/main.py:1046
+msgid "Add Preview"
+msgstr "Önizleme Ekle"
+
+#: src/main.py:1041
+msgid "Add"
+msgstr "Ekle"
+
+#: src/main.py:1127
+msgid "Show in Files"
+msgstr "Dosyalarda Göster"
+
+#: src/main.py:1129
+msgid "Error!"
+msgstr "Hata!"
+
+#: src/main.py:1130
+msgid "Could not locate output folder!"
+msgstr "Çıktı klasörü bulunamadı!"
+
+#: src/main.py:1212
+msgid "Choose where to save"
+msgstr "Nereye kaydedileceğini seç"
+
+#: src/main.py:1215
+msgid "Image files"
+msgstr "Resim dosyaları"
+
+#: src/main.py:1226
+msgid "Choose an image file"
+msgstr "Resim dosyası seç"
+
+#: src/main.py:1275
+msgid "Open image file"
+msgstr "Resim Dosyası Aç"
+
+#: src/main.py:1305
+msgid "Options Menu"
+msgstr "Seçenekler Menüsü"
+
+#: src/main.py:1312
+msgid "Enable Crop"
+msgstr "Kırpmayı Etkinleştir"
+
+#: src/main.py:1333
+msgid "Toggle Circle"
+msgstr "Daireyi Aç/Kapat"
+
+#: src/main.py:1338
+msgid "Remove Preview"
+msgstr "Önizlemeyi Kaldır"
+
+#: src/main.py:1447
+msgid "Export to Downloads folder"
+msgstr "İndirilenler klasörüne dışa aktar"
+
+#: src/main.py:1448
+msgid "Image file exported to Downloads."
+msgstr "Resim dosyası İndirilenler'e aktarıldı."
+
+#: src/main.py:1450
+msgid "Export to Pictures folder"
+msgstr "Resimler klasörüne aktar"
+
+#: src/main.py:1451
+msgid "Image file exported to Pictures."
+msgstr "Resim dosyası Resimler'e aktarıldı."
+
+#: src/main.py:1453
+msgid "Overwrite Image"
+msgstr "Resmin Üzerine Yaz"
+
+#: src/main.py:1454
+msgid "Image file overwritten."
+msgstr "Resim dosyasının üzerine yazıldı."
+
+#: src/main.py:2135
 msgid "Reset rotation"
 msgstr "Döndürmeyi sıfırla"
 
-#: src/main.py:1821
+#: src/main.py:2147
 msgid "Flip Vertical"
 msgstr "Dikey Çevir"
 
-#: src/main.py:1824
+#: src/main.py:2150
 msgid "Flip Horizontal"
 msgstr "Yatay Çevir"
 
-#: src/main.py:1837
+#: src/main.py:2163
 msgid "No Downscale"
 msgstr "Küçültme!"
 
-#: src/main.py:1842
+#: src/main.py:2168
 msgid "Max 184x184"
 msgstr "Azami 184x184"
 
-#: src/main.py:1847
+#: src/main.py:2173
 msgid "Max 1000x1000"
 msgstr "Azami 1000x1000"
 
-#: src/main.py:1872
+#: src/main.py:2198
 msgid "Export as PNG"
 msgstr "PNG Olarak Dışa Aktar"
 
-#: src/main.py:1877
+#: src/main.py:2203
 msgid "Discard EXIF"
 msgstr "EXIF Verilerinden Vazgeç"
 
-#: src/main.py:1884
+#: src/main.py:2210
 msgid "Sharpen"
 msgstr "Keskinleştir"
 
-#: src/main.py:1889
+#: src/main.py:2215
 msgid "Grayscale"
 msgstr "Gri Tonlamalı"
 
-#: src/main.py:1895
+#: src/main.py:2221
 msgid "Export As"
 msgstr "Dışa Farklı Aktar"
 
-#: src/main.py:1899
+#: src/main.py:2225
 msgid "Preferences"
 msgstr "Tercihler"
 
-#. TRANSLATORS: After this we will add "Avvie", e.g. for english it will be "About Avvie"
-#: src/main.py:1904
-msgid "About "
-msgstr "Hakkında"
+#: src/main.py:2230
+#, python-format
+msgid "About %s"
+msgstr "%s Hakkında"
 
-#. TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-#: src/main.py:1990
+#: src/main.py:2312
 msgid "translator-credits"
 msgstr "Sabri Ünal <libreajans@gmail.com>"

--- a/src/main.py
+++ b/src/main.py
@@ -889,10 +889,14 @@ class SettingsDialog(Adw.PreferencesWindow):
         page.add(behavior_group)
 
 
-        options = Gtk.StringList.new(["None", "Cross", "Rule of thirds"])
+        options = Gtk.StringList.new([
+            _("None"),
+            _("Cross"),
+            _("Rule of thirds")
+        ])
 
         self.guide_combo_row = Adw.ComboRow()
-        self.guide_combo_row.set_title("Guide Mode")
+        self.guide_combo_row.set_title(_("Guide Mode"))
         self.guide_combo_row.set_model(options)
         self.guide_combo_row.set_selected(config.get("guide-mode", 1))
 


### PR DESCRIPTION
### appdata: Update appdata

- Add vcs-browser and translate URLs
- Remove categories that already presented in the desktop file
- Mark release description as untranslatable

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories

### ui: Mark 4 strings translatable

- Guide Mode
- None, Cross, Rule of thirds

### po: Update the pot file

- Add new strings

### po: Update Turkish translation

### flatpak: update runtime

- Use more recent version of GNOME runtime.