### PR TITLE
Appdata related changes

### DIFF
--- a/data/com.github.taiko2k.avvie.appdata.xml.in
+++ b/data/com.github.taiko2k.avvie.appdata.xml.in
@@ -4,6 +4,9 @@
   <id>com.github.taiko2k.avvie</id>
   <name>Avvie</name>
   <developer_name>Taiko2k</developer_name>
+  <developer id="io.github.taiko2k">
+    <name>Lorenzo Paderi</name>
+  </developer>
   <summary>Quick and easy image cropping</summary>
   <launchable type="desktop-id">com.github.taiko2k.avvie.desktop</launchable>
   <metadata_license>CC-BY-SA-3.0</metadata_license>

--- a/data/com.github.taiko2k.avvie.appdata.xml.in
+++ b/data/com.github.taiko2k.avvie.appdata.xml.in
@@ -27,7 +27,7 @@
 
   <releases>
     <release version="2.4" date="2023-07-14">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Added option for lossless JPEG cropping</li>
           <li>Added option to set JPEG export quality</li>


### PR DESCRIPTION
### appdata: translate=no properties

It appears that the appstream project no longer supports
`translatable=no` properties, and gettext extract them as translatable.

I opened an issue to inform about the situation, but `translatable=no`
properties are not accepted by developers. You can find the issue
here: `https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID. Also Appstream decided to use rdns structure for developer ID.

It allows reverse-dns IDs like sh.cozy, de.geigi or Fediverse handle (like @user@example.org)

> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

Source: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer